### PR TITLE
revert: fix(dp): tmp workaround to always have "as" for "ips"

### DIFF
--- a/pkg/agent/dataplane.go
+++ b/pkg/agent/dataplane.go
@@ -138,24 +138,6 @@ func buildDataplaneConfig(ag *gwintapi.GatewayAgent) (*dataplane.GatewayConfig, 
 					}
 				}
 
-				// TODO remove it after dataplane is fixed to properly handle empty AS (related to removing import vrf and it not working w/o NAT)
-				if len(as) == 0 {
-					for _, ipEntry := range ips {
-						switch {
-						case ipEntry.GetCidr() != "":
-							as = append(as, &dataplane.PeeringAs{
-								Rule: &dataplane.PeeringAs_Cidr{Cidr: ipEntry.GetCidr()},
-							})
-						case ipEntry.GetNot() != "":
-							as = append(as, &dataplane.PeeringAs{
-								Rule: &dataplane.PeeringAs_Not{Not: ipEntry.GetNot()},
-							})
-						default:
-							return nil, fmt.Errorf("invalid IP entry in peering %s / vpc %s: %v", peeringName, vpcName, ipEntry) //nolint:goerr113
-						}
-					}
-				}
-
 				exposes = append(exposes, &dataplane.Expose{
 					Ips: ips,
 					As:  as,


### PR DESCRIPTION
This reverts commit beb14948d3584f5194be1d6efc964d243e708c5a.

To be merged after https://github.com/githedgehog/dataplane/pull/726

Fixes #138 