### PR TITLE
feat(api,ctrl): introduce nice iface names with either pci/kernel

### DIFF
--- a/api/gateway/v1alpha1/gateway_types_test.go
+++ b/api/gateway/v1alpha1/gateway_types_test.go
@@ -31,9 +31,10 @@ func gwa(name string, f ...func(gw *v1alpha1.Gateway)) *v1alpha1.Gateway {
 			VTEPMAC:    "ca:fe:ba:be:00:01",
 			VTEPMTU:    1500,
 			Interfaces: map[string]v1alpha1.GatewayInterface{
-				"eth0": {
-					IPs: []string{"172.30.128.3/31"},
-					MTU: 1500,
+				"port0": {
+					Kernel: "eth0",
+					IPs:    []string{"172.30.128.3/31"},
+					MTU:    1500,
 				},
 			},
 			Neighbors: []v1alpha1.GatewayBGPNeighbor{

--- a/config/crd/bases/gateway.githedgehog.com_gateways.yaml
+++ b/config/crd/bases/gateway.githedgehog.com_gateways.yaml
@@ -71,6 +71,10 @@ spec:
                       items:
                         type: string
                       type: array
+                    kernel:
+                      description: Kernel is the kernel name of the interface to use
+                        (required for kernel driver), e.g. enp2s1
+                      type: string
                     mtu:
                       description: MTU for the interface
                       format: int32

--- a/config/crd/bases/gwint.githedgehog.com_gatewayagents.yaml
+++ b/config/crd/bases/gwint.githedgehog.com_gatewayagents.yaml
@@ -90,6 +90,10 @@ spec:
                           items:
                             type: string
                           type: array
+                        kernel:
+                          description: Kernel is the kernel name of the interface
+                            to use (required for kernel driver), e.g. enp2s1
+                          type: string
                         mtu:
                           description: MTU for the interface
                           format: int32

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,6 +67,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `pci` _string_ | PCI address of the interface (required for DPDK driver), e.g. 0000:00:01.0 |  |  |
+| `kernel` _string_ | Kernel is the kernel name of the interface to use (required for kernel driver), e.g. enp2s1 |  |  |
 | `ips` _string array_ | IPs is the list of IP address to assign to the interface |  |  |
 | `mtu` _integer_ | MTU for the interface |  |  |
 


### PR DESCRIPTION
port1:
  pci: 0000:f1:00.0
port2:
  pci: 0000:f1:00.1

results into: --interface port1=pci@0000:f1:00.0

port1:
  kernel: enp2s1
port2:
  kernel: enp2s2

results into: --interface port1=kernel@enp2s1