### PR TITLE
feat(ctrl): change entrypoint of frr container

### DIFF
--- a/pkg/ctrl/gateway_ctrl.go
+++ b/pkg/ctrl/gateway_ctrl.go
@@ -680,8 +680,9 @@ func (r *GatewayReconciler) deployGateway(ctx context.Context, gw *gwapi.Gateway
 							{
 								Name:    "frr",
 								Image:   r.cfg.FRRRef,
-								Command: []string{"/libexec/frr/docker-start"},
+								Command: []string{"/bin/tini", "--"},
 								Args: []string{
+									"/libexec/frr/docker-start",
 									"--sock-path", filepath.Join(frrRunMountPath, frrAgentSocket),
 									"--reloader", "/libexec/frr/frr-reload.py",
 									"--bindir", "/bin",


### PR DESCRIPTION
The newer images for FRR contain tini, but we override the image entry point. Set the entrypoint to tini so that it propagates SIGTERM/SIGINT and the containers gracefully close on deletion without the grace period needing to expire.