### PR TITLE
feat: Add BMP enablement for dataplane CLI

### DIFF
--- a/pkg/ctrl/gateway_ctrl.go
+++ b/pkg/ctrl/gateway_ctrl.go
@@ -497,6 +497,9 @@ func (r *GatewayReconciler) deployGateway(ctx context.Context, gw *gwapi.Gateway
 			"--cpi-sock-path", filepath.Join(frrRunMountPath, cpiSocket),
 			"--frr-agent-path", filepath.Join(frrRunMountPath, frrAgentSocket),
 			"--metrics-address", fmt.Sprintf("127.0.0.1:%d", r.cfg.DataplaneMetricsPort),
+			"--bmp-enable",
+			"--bmp-address", "127.0.0.1:5000", // TODO: make it available via config
+			"--bmp-interval", "10000",
 		}
 		if gw.Spec.Profiling.Enabled {
 			// args = append(args, "--pyroscope-url", "http://alloy-gw.fab.svc.cluster.local:4040")


### PR DESCRIPTION
The BMP listener port is hardcoded for now, later
we will make it available via `GatewayConfig`

@Frostman we are having hardcoded values cause it's purely for internal usage. But if we need to make it configurable please let me know